### PR TITLE
Fix/heat cool bugfixes

### DIFF
--- a/dist/thermostat_card.lib.js
+++ b/dist/thermostat_card.lib.js
@@ -135,6 +135,14 @@ export default class ThermostatUI {
             to = target_index;
           }
           break;
+        case 'heat_cool':
+          this._load_icon(this.hvac_state, 'sync');
+
+          if (target_index >= ambient_index) {
+            from = ambient_index;
+            to = target_index;
+          }
+          break;
         case 'auto':
           this._load_icon(this.hvac_state, 'atom');
           
@@ -157,6 +165,8 @@ export default class ThermostatUI {
 
       switch (this.hvac_state) {
         case 'cool':
+          this._load_icon(this.hvac_state, 'snowflake');
+
           if (high_index < ambient_index) {
             from = high_index;
             to = ambient_index;
@@ -165,6 +175,8 @@ export default class ThermostatUI {
           }
           break;
         case 'heat':
+          this._load_icon(this.hvac_state, 'fire');
+
           if (low_index > ambient_index) {
             from = ambient_index;
             to = low_index;
@@ -172,7 +184,26 @@ export default class ThermostatUI {
             this._updateTemperatureSlot(this._low, 8, `temperature_slot_2`);
           }
           break;
+        case 'heat_cool':
+          this._load_icon(this.hvac_state, 'sync');
+
+          if (high_index < ambient_index) {
+            from = high_index;
+            to = ambient_index;
+            this._updateTemperatureSlot(this.ambient, 8, `temperature_slot_3`);
+            this._updateTemperatureSlot(this._high, -8, `temperature_slot_2`);
+          }
+          if (low_index > ambient_index) {
+            from = ambient_index;
+            to = low_index;
+            this._updateTemperatureSlot(this.ambient, -8, `temperature_slot_1`);
+            this._updateTemperatureSlot(this._low, 8, `temperature_slot_2`);
+          }
+          break;
+
         case 'off':
+          this._load_icon(this.hvac_state, 'power');
+
           if (high_index < ambient_index) {
             from = high_index;
             to = ambient_index;
@@ -400,9 +431,14 @@ export default class ThermostatUI {
         case 'auto':
           icon = 'atom';
           break;
+        case 'heat_cool':
+          icon = 'sync';
+          break;
         case 'off':
           icon = 'power';
           break;
+        default:
+          icon = 'help';
       }
       let d = document.createElement('span');
       d.innerHTML = `<ha-icon class="modeicon ${mode}" icon="mdi:${icon}"></ha-icon>`


### PR DESCRIPTION
Thanks for the card @fineemb!

Since I use heat/cool mode a lot, I noticed that there were a few issues:

1. Added dual_state bool to track being in a state that makes sense to support dual temp adjustment (this.dual wasn't enough on it's own as it applies even when the hvac mode is a single-temp mode like heat or cool.)
2. Fixed the logic in heat_cool and off modes to put the temp labels back in place
3. Reminded it to load the mode icons
4. Set from and to values correctly when in heat_cool mode

Just now I've realised my prettier config in vscode got a hold of it, and that's the rest of the changes.

I've had this running a few months now in use with heat pumps that run in heat_cool most of the time and electric heaters that run in heat mode, and everything seems good enough, so I don't think I've introduced any horrible bugs.

If there's anything you'd like changed let me know.